### PR TITLE
force stay on activity section after refreshing and filtering on past activity all

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -52,9 +52,8 @@ class ActivityController extends Controller
       ->paginate(3, ['*'], 'available_page')
       ->appends(request()->query());
 
-    $oldActivities = Activity::withCount('enrolled') // ✅ ADDED
+    $oldActivities = Activity::withCount('enrolled')
       ->whereNull('deleted_at')
-      ->whereIn('id', $enrolledIds)
       ->where('endtime', '<', now())
       ->orderBy($colO, $dirO)
       ->paginate(3, ['*'], 'old_page')

--- a/resources/views/activity/index.blade.php
+++ b/resources/views/activity/index.blade.php
@@ -60,3 +60,12 @@
         </div>
     </div>
 </x-app-layout>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        if (sessionStorage.scrollPos) window.scrollTo(0, sessionStorage.scrollPos);
+    });
+    window.onbeforeunload = () => {
+        sessionStorage.scrollPos = window.scrollY;
+    };
+</script>


### PR DESCRIPTION
Updated the “old activities” filter to show all past activities, not only enrolled ones.

Added a scroll-position restore script so the page automatically returns to the previous section when using filters or pagination.